### PR TITLE
Better plugin handling

### DIFF
--- a/base/setup_fabsim.py
+++ b/base/setup_fabsim.py
@@ -5,25 +5,6 @@ from fabric.contrib.project import *
 import fileinput
 import sys
 
-def activate_plugin(name):
-    """
-    Updates fabfile.py to enable plugin.
-    """
-    found = False
-    fabfile_loc = "%s/fabfile.py" % (env.localroot)
-
-    for line in fileinput.input(fabfile_loc, inplace=1):
-        if name in line:
-            found = True
-            if line[0] == "#":
-                line = line[1:]
-        sys.stdout.write(line)
-
-    # if the commented pattern is not found, then we need to append a new import at the end of fabfile.py.
-    if found == False:
-        with open(fabfile_loc, "a") as myfile:
-            myfile.write("from plugins.%s.%s import *\n" % (name, name))
-
 @task
 def install_plugin(name):
     """
@@ -38,7 +19,6 @@ def install_plugin(name):
 
     local("git clone %s %s/%s" % (info["repository"], plugin_dir, name))
 
-    activate_plugin("%s" % (name))
 
 def add_local_paths(module_name):
     # This variable encodes the default location for templates.

--- a/fabfile.py
+++ b/fabfile.py
@@ -5,5 +5,21 @@
 # fabfile.py is the main FabSim interface file. Here one can freely include or omit subsections of the FabSim toolkit,
 # to modify the enabled functionalities.
 
+import yaml
+import importlib
+
 from base.fab import *
-#from deploy.repast.fabRepast import *
+
+config = yaml.load(open(os.path.join(env.localroot, 'deploy', 'plugins.yml')))
+for key in config.keys():
+    try:
+        plugin = importlib.import_module('plugins.{}.{}'.format(key, key))
+        plugin_dict = plugin.__dict__
+        try:
+            to_import = plugin.__all__
+        except AttributeError:
+            to_import = [name for name in plugin_dict if not name.startswith('_')]
+        globals().update({name: plugin_dict[name] for name in to_import})
+    except ModuleNotFoundError:
+        pass
+


### PR DESCRIPTION
This does away with the issue where plug-ins need to be reactivated because fabfile.py is overwritten. There are some issues with it though. Import everything from a plugin is a bad idea. I would suggest to change the plugin "API" so that each plugin module includes a variable called "__exported_tasks__" or something along those lines. Just with the names that this module exports. This way we can import only those. That being said I don't know enough about how fabsim is used to know if that will work.

This is in reference to issue #30 