### PR TITLE
A bug in templates.py

### DIFF
--- a/deploy/templates.py
+++ b/deploy/templates.py
@@ -25,9 +25,9 @@ def script_template_content(template_name):
     if os.path.exists(template_file_path):
       source=open(template_file_path)
 
-  if source:
+  try:
     return template(source.read())
-  else:
+  except UnboundLocalError:
     print("FabSim Error: could not find template file. FabSim looked for it in the following directories: ", env.local_templates_path)
 
 def script_template_save_temporary(content):


### PR DESCRIPTION
I think theres a bug in templates.py since the code snippet I have changed would otherwise fail with an exception rather than print the error message. That is because the the source variable will be undefined if the condition above fails.