### PR TITLE
Fix pep-8 check

### DIFF
--- a/fabsim/base/fab.py
+++ b/fabsim/base/fab.py
@@ -387,7 +387,8 @@ def find_config_file_path(
     if path_used is None:
         if ExceptWhenNotFound:
             raise Exception(
-                "Error: config file directory '{}' not found in: ".format(name),
+                "Error: config file directory '{}' "
+                "not found in: ".format(name),
                 env.local_config_file_path,
             )
         else:


### PR DESCRIPTION
Sorry I think I broke the PEP-8 check in the test suite. 
That check fails if line is > 79 chars long, but my changes
(PR #213) introduced an 80 char line.

Thanks for the really useful code! 