### PR TITLE
Use SSHPASS for sshpass if present in environment

### DIFF
--- a/docs/advanced_topics.md
+++ b/docs/advanced_topics.md
@@ -253,4 +253,24 @@ archer2:
 ```
 
 
+## SSH password authentication with `sshpass`
+If (in addition to a public key which can be set in `~/.ssh/config`) a password is required for SSH authentication,  
+set `manual_sshpass: true` in your `machine.yml`.  
 
+Example:
+```yml
+myMachine:
+  remote: myHost # see ~/.ssh/config
+  manual_sshpass: true
+```
+The password may then be provided as an environment variable:
+```bash
+# Avoid leaking password to ~/.bash_history
+read -sr SSHPASS && export SSHPASS
+# SSHPASS is automatically used if manual_sshpass is set
+fabsim myMachine dummy:dummy_test
+```
+
+It is also possible to provide a plain text file containing the password by including `sshpass: 'path/to/password.secret'` in your `machine.yml` instead of providing it as an environment variable.  
+Make sure that the password is not readable by other users with `chmod g=-rwx,o=-rwx path/to/password.secret`.  
+**NOTE:** This does not provide any real security and the use of this method is highly discouraged!

--- a/fabsim/base/env.py
+++ b/fabsim/base/env.py
@@ -92,5 +92,6 @@ env = _lookupDict(
         "default_ssh_config_path": os.path.join(
             os.path.expanduser("~"), ".ssh", "config"
         ),
+        "env_sshpass": "SSHPASS" in os.environ,
     }
 )

--- a/fabsim/base/fab.py
+++ b/fabsim/base/fab.py
@@ -129,12 +129,13 @@ def fetch_results(
     if not os.path.isdir(env.job_results_local):
         os.makedirs(env.job_results_local)
 
-    if env.manual_sshpass:
+    if env.manual_sshpass or env.env_sshpass:
+        sshpass_cmd = "sshpass -e" if env.env_sshpass else "sshpass -f $sshpass"
         local(
             template(
-                "rsync -pthrvz -e 'sshpass -f $sshpass ssh -p $port' {}"
+                "rsync -pthrvz -e '{} ssh -p $port' {}"
                 "$username@$remote:$job_results/{}  "
-                "$job_results_local".format(includes_files, regex)
+                "$job_results_local".format(sshpass_cmd, includes_files, regex)
             )
         )
     elif env.manual_gsissh:
@@ -272,10 +273,11 @@ def put_configs(config: str) -> None:
             )
         )
 
-    elif env.manual_sshpass:
+    elif env.manual_sshpass or env.env_sshpass:
+        sshpass_cmd = "sshpass -e" if env.env_sshpass else "sshpass -f $sshpass"
         local(
             template(
-                "rsync -pthrvz --rsh='sshpass -f $sshpass ssh  -p 22  ' "
+                f"rsync -pthrvz --rsh='{sshpass_cmd} ssh  -p 22  ' "
                 "$job_config_path_local/ "
                 "$username@$remote:$job_config_path/"
             )
@@ -955,13 +957,14 @@ def job_transmission(*job_args):
                     )
                 )
             )
-        elif env.manual_sshpass:
+        elif env.manual_sshpass or env.env_sshpass:
+            sshpass_cmd = "sshpass -e" if env.env_sshpass else "sshpass -f $sshpass"
             # TODO: maybe the better option here is to overwrite the
             #       rsync_project
             local(
                 template(
                     "rsync -pthrvz "
-                    "--rsh='sshpass -f $sshpass ssh  -p 22  ' "
+                    f"--rsh='{sshpass_cmd} ssh  -p 22  ' "
                     "{}/ $username@$remote:{}/ ".format(sync_src, sync_dst)
                 )
             )

--- a/fabsim/base/fab.py
+++ b/fabsim/base/fab.py
@@ -129,7 +129,7 @@ def fetch_results(
     if not os.path.isdir(env.job_results_local):
         os.makedirs(env.job_results_local)
 
-    if env.manual_sshpass or env.env_sshpass:
+    if env.manual_sshpass:
         sshpass_cmd = "sshpass -e" if env.env_sshpass else "sshpass -f $sshpass"
         local(
             template(
@@ -273,7 +273,7 @@ def put_configs(config: str) -> None:
             )
         )
 
-    elif env.manual_sshpass or env.env_sshpass:
+    elif env.manual_sshpass:
         sshpass_cmd = "sshpass -e" if env.env_sshpass else "sshpass -f $sshpass"
         local(
             template(
@@ -957,7 +957,7 @@ def job_transmission(*job_args):
                     )
                 )
             )
-        elif env.manual_sshpass or env.env_sshpass:
+        elif env.manual_sshpass:
             sshpass_cmd = "sshpass -e" if env.env_sshpass else "sshpass -f $sshpass"
             # TODO: maybe the better option here is to overwrite the
             #       rsync_project

--- a/fabsim/base/fab.py
+++ b/fabsim/base/fab.py
@@ -130,12 +130,13 @@ def fetch_results(
         os.makedirs(env.job_results_local)
 
     if env.manual_sshpass:
-        sshpass_cmd = "sshpass -e" if env.env_sshpass else "sshpass -f $sshpass"
+        sshpass_args = "-e" if env.env_sshpass else "-f $sshpass"
         local(
             template(
-                "rsync -pthrvz -e '{} ssh -p $port' {}"
+                "rsync -pthrvz -e 'sshpass {} ssh -p $port' {}"
                 "$username@$remote:$job_results/{}  "
-                "$job_results_local".format(sshpass_cmd, includes_files, regex)
+                "$job_results_local".format(
+                    sshpass_args, includes_files, regex)
             )
         )
     elif env.manual_gsissh:
@@ -274,10 +275,10 @@ def put_configs(config: str) -> None:
         )
 
     elif env.manual_sshpass:
-        sshpass_cmd = "sshpass -e" if env.env_sshpass else "sshpass -f $sshpass"
+        sshpass_args = "-e" if env.env_sshpass else "-f $sshpass"
         local(
             template(
-                f"rsync -pthrvz --rsh='{sshpass_cmd} ssh  -p 22  ' "
+                f"rsync -pthrvz --rsh='sshpass {sshpass_args} ssh  -p 22  ' "
                 "$job_config_path_local/ "
                 "$username@$remote:$job_config_path/"
             )
@@ -958,13 +959,13 @@ def job_transmission(*job_args):
                 )
             )
         elif env.manual_sshpass:
-            sshpass_cmd = "sshpass -e" if env.env_sshpass else "sshpass -f $sshpass"
+            sshpass_args = "-e" if env.env_sshpass else "-f $sshpass"
             # TODO: maybe the better option here is to overwrite the
             #       rsync_project
             local(
                 template(
                     "rsync -pthrvz "
-                    f"--rsh='{sshpass_cmd} ssh  -p 22  ' "
+                    f"--rsh='sshpass {sshpass_args} ssh  -p 22  ' "
                     "{}/ $username@$remote:{}/ ".format(sync_src, sync_dst)
                 )
             )

--- a/fabsim/base/manage_remote_job.py
+++ b/fabsim/base/manage_remote_job.py
@@ -40,9 +40,10 @@ def jobs_list(quiet: Optional[bool] = False) -> str:
         # output = local(template("$stat "), capture=quiet).splitlines()
         output = run(template("$stat "), capture=quiet)
         return output
-    
+
     elif env.manual_sshpass:
-        sshpass_cmd = 'sshpass -e' if env.env_sshpass else "sshpass -f '%(sshpass)s'" % env
+        sshpass_args = "-e" if env.env_sshpass else "-f '%(sshpass)s'" % env
+        sshpass_cmd = f"sshpass {sshpass_args}"
         pre_cmd = sshpass_cmd + " ssh %(username)s@%(remote)s " % env
         manual_command = template("$stat")
         # manual_command = '"' + manual_command + '"'
@@ -104,7 +105,8 @@ def cancel_job(jobID: Optional[str] = None) -> None:
     ):
         local(template(template.template("$cancel_job_command")))
     elif env.manual_sshpass:
-        sshpass_cmd = 'sshpass -e' if env.env_sshpass else "sshpass -f '%(sshpass)s'" % env
+        sshpass_args = "-e" if env.env_sshpass else "-f '%(sshpass)s'" % env
+        sshpass_cmd = f"sshpass {sshpass_args}"
         pre_cmd = sshpass_cmd + " ssh %(username)s@%(remote)s " % env
         manual_command = template("$cancel_job_command $jobID")
         local(pre_cmd + "'" + manual_command + "'", capture=False)

--- a/fabsim/base/manage_remote_job.py
+++ b/fabsim/base/manage_remote_job.py
@@ -40,9 +40,10 @@ def jobs_list(quiet: Optional[bool] = False) -> str:
         # output = local(template("$stat "), capture=quiet).splitlines()
         output = run(template("$stat "), capture=quiet)
         return output
-
-    elif env.manual_sshpass:
-        pre_cmd = "sshpass -f '%(sshpass)s' ssh %(username)s@%(remote)s " % env
+    
+    elif env.manual_sshpass or env.env_sshpass:
+        sshpass_cmd = 'sshpass -e' if env.env_sshpass else "sshpass -f '%(sshpass)s'" % env
+        pre_cmd = sshpass_cmd + " ssh %(username)s@%(remote)s " % env
         manual_command = template("$stat")
         # manual_command = '"' + manual_command + '"'
         print("manual_command", manual_command)
@@ -102,8 +103,9 @@ def cancel_job(jobID: Optional[str] = None) -> None:
         and env.dispatch_jobs_on_localhost
     ):
         local(template(template.template("$cancel_job_command")))
-    elif env.manual_sshpass:
-        pre_cmd = "sshpass -f '%(sshpass)s' ssh %(username)s@%(remote)s " % env
+    elif env.manual_sshpass or env.env_sshpass:
+        sshpass_cmd = 'sshpass -e' if env.env_sshpass else "sshpass -f '%(sshpass)s'" % env
+        pre_cmd = sshpass_cmd + " ssh %(username)s@%(remote)s " % env
         manual_command = template("$cancel_job_command $jobID")
         local(pre_cmd + "'" + manual_command + "'", capture=False)
 

--- a/fabsim/base/manage_remote_job.py
+++ b/fabsim/base/manage_remote_job.py
@@ -41,7 +41,7 @@ def jobs_list(quiet: Optional[bool] = False) -> str:
         output = run(template("$stat "), capture=quiet)
         return output
     
-    elif env.manual_sshpass or env.env_sshpass:
+    elif env.manual_sshpass:
         sshpass_cmd = 'sshpass -e' if env.env_sshpass else "sshpass -f '%(sshpass)s'" % env
         pre_cmd = sshpass_cmd + " ssh %(username)s@%(remote)s " % env
         manual_command = template("$stat")
@@ -103,7 +103,7 @@ def cancel_job(jobID: Optional[str] = None) -> None:
         and env.dispatch_jobs_on_localhost
     ):
         local(template(template.template("$cancel_job_command")))
-    elif env.manual_sshpass or env.env_sshpass:
+    elif env.manual_sshpass:
         sshpass_cmd = 'sshpass -e' if env.env_sshpass else "sshpass -f '%(sshpass)s'" % env
         pre_cmd = sshpass_cmd + " ssh %(username)s@%(remote)s " % env
         manual_command = template("$cancel_job_command $jobID")

--- a/fabsim/base/networks.py
+++ b/fabsim/base/networks.py
@@ -162,10 +162,10 @@ def manual_sshpass(
 
     commands.append(cmd)
     manual_command = " && ".join(commands)
-    if not hasattr(env, "sshpass"):
-        raise ValueError("sshpass value did not set for this remote machine")
-
-    pre_cmd = "sshpass -f '%(sshpass)s' ssh %(username)s@%(remote)s " % env
+    if not hasattr(env, "sshpass") and not env.env_sshpass:
+        raise ValueError("Neither SSHPASS set in environment nor sshpass value set for this remote machine")
+    sshpass_cmd = 'sshpass -e' if env.env_sshpass else "sshpass -f '%(sshpass)s'" % env
+    pre_cmd = sshpass_cmd + " ssh %(username)s@%(remote)s " % env
     return local(pre_cmd + "'" + manual_command + "'", capture=capture)
 
 

--- a/fabsim/base/networks.py
+++ b/fabsim/base/networks.py
@@ -163,9 +163,10 @@ def manual_sshpass(
     commands.append(cmd)
     manual_command = " && ".join(commands)
     if not hasattr(env, "sshpass") and not env.env_sshpass:
-        raise ValueError("Neither SSHPASS set in environment nor sshpass value set for this remote machine")
-    sshpass_cmd = 'sshpass -e' if env.env_sshpass else "sshpass -f '%(sshpass)s'" % env
-    pre_cmd = sshpass_cmd + " ssh %(username)s@%(remote)s " % env
+        raise ValueError("Neither SSHPASS set in environment" +
+                         " nor sshpass value set for this remote machine")
+    sshpass_args = "-e" if env.env_sshpass else "-f '%(sshpass)s'" % env
+    pre_cmd = f"sshpass {sshpass_args}" + " ssh %(username)s@%(remote)s " % env
     return local(pre_cmd + "'" + manual_command + "'", capture=capture)
 
 

--- a/fabsim/deploy/machines.yml
+++ b/fabsim/deploy/machines.yml
@@ -76,7 +76,7 @@ default:
   # Flag to use GSISSH instead of SSH.
   manual_gsissh: false
   
-  # Flag to use sshpass within SSH.
+  # Flag to use sshpass within SSH (requires that either value for sshpass is set with filename of plaintext password file for this machine or SSHPASS set in environment)
   manual_sshpass: false
 
   # Flag to use 'monsoon mode', which avoids rsync altogether and copies 


### PR DESCRIPTION
## Motivation
Rather than providing the SSH password in a plain text file, it may be more convenient or secure to set it as an environment variable before running `fabsim`. 
Luckily, this is trivially possible using `sshpass -e`.

## Usage
```bash
SSHPASS=myPassword fabsim myMachine dummy:dummy_test
```
or 
```bash
export SSHPASS=myPassword
fabsim myMachine dummy:dummy_test
```
or 
```bash
read -sr SSHPASS
export SSHPASS
fabsim myMachine dummy:dummy_test
```