### PR TITLE
Add details of FabNESO plugin

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -110,3 +110,10 @@ FabUQCampaign is a FabSim3 plugin for a climate modelling. It used to run an ens
 	* FabUQCampaign 2D ocean model documentation : [:fontawesome-solid-book:](https://github.com/wedeling/FabUQCampaign/blob/master/Tutorial_ocean.md)
 
 
+#### FabNESO
+
+FabNESO is a FabSim3 plugin for [Neptune Exploratory SOftware (NESO)](https://github.com/ExCALIBUR-NEPTUNE/NESO). 
+It can be used to run both single instances and ensemble runs of NESO simulations.
+
+* FabNESO github repository : [:octicons-mark-github-16:](https://github.com/UCL/FabNESO)
+* FabNESO documentation : [:fontawesome-solid-book:](https://github.com/UCL/FabNESO/blob/main/README.md)

--- a/fabsim/deploy/plugins.yml
+++ b/fabsim/deploy/plugins.yml
@@ -59,3 +59,6 @@ FabEco:
   
 FabOasis:
   repository: https://github.com/arindamsaha1507/FabOasis
+
+FabNESO:
+  repository: https://github.com/UCL/FabNESO


### PR DESCRIPTION
Fixes UCL/FabNESO#13

Adds [FabNESO plugin](https://github.com/UCL/FabNESO) to plugin list in `fabsim/deploy/plugins.yml` and adds a brief description and repository / documentation links to `docs/plugins.md`.