### PR TITLE
Resolve nested variable references in `job_dispatch` definition

### DIFF
--- a/fabsim/base/fab.py
+++ b/fabsim/base/fab.py
@@ -1029,14 +1029,16 @@ def job_submission(*job_args):
             cmd = template(
                 "ssh $remote_compute "
                 "-C '$job_dispatch {}'".format(job_script),
-                number_of_iterations=2,  # Allow for variable refs in job_dispatch
+                # Allow for variable references in job_dispatch definition
+                number_of_iterations=2,
             )
             run(cmd, cd=env.pather.dirname(job_script))
         else:
             run(
                 cmd=template(
                     "$job_dispatch {}".format(job_script),
-                    number_of_iterations=2,  # Allow for variable refs in job_dispatch
+                    # Allow for variable references in job_dispatch definition
+                    number_of_iterations=2,
                 ),
                 cd=env.pather.dirname(job_script),
             )

--- a/fabsim/base/fab.py
+++ b/fabsim/base/fab.py
@@ -1028,12 +1028,16 @@ def job_submission(*job_args):
         elif env.ssh_monsoon_mode:
             cmd = template(
                 "ssh $remote_compute "
-                "-C '$job_dispatch {}'".format(job_script)
+                "-C '$job_dispatch {}'".format(job_script),
+                number_of_iterations=2,  # Allow for variable refs in job_dispatch
             )
             run(cmd, cd=env.pather.dirname(job_script))
         else:
             run(
-                cmd=template("$job_dispatch {}".format(job_script)),
+                cmd=template(
+                    "$job_dispatch {}".format(job_script),
+                    number_of_iterations=2,  # Allow for variable refs in job_dispatch
+                ),
                 cd=env.pather.dirname(job_script),
             )
 


### PR DESCRIPTION
Fixes #256 

Adds a `number_of_iterations=2` argument to calls to `fabsim.deploy.templates.template` when constructing job submission command on remote machines, to ensure that any references to other variables in the definition of the `job_dispatch` variable (for example the default value used for `job_dispatch` on `archer2`) are subsituted correctly.