### PR TITLE
Update ARCHER2 batch job header template and default run command

### DIFF
--- a/fabsim/deploy/machines.yml
+++ b/fabsim/deploy/machines.yml
@@ -495,7 +495,7 @@ archer2:
   budget: "d137"
   project: "d137"
   corespernode: 128
-  run_command: "srun -n $cores"
+  run_command: "srun --distribution=block:block --hint=nomultithread"
   qos_name: "standard"
   # list of available partitions : sinfo --Format=partition
   job_dispatch: "cd /work/$project/$project/$username ; sbatch"

--- a/fabsim/deploy/templates/slurm-archer2
+++ b/fabsim/deploy/templates/slurm-archer2
@@ -6,6 +6,9 @@
 ## task per node
 #SBATCH --tasks-per-node=$corespernode
 
+## number of cpus per task
+#SBATCH --cpus-per-task=$cpuspertask
+
 ## wall time in format MINUTES:SECONDS
 #SBATCH --time=$job_wall_time
 
@@ -21,3 +24,5 @@
 #SBATCH --partition=$partition_name
 #SBATCH --qos=$qos_name
 
+# Ensure the cpus-per-task option is propagated to srun commands
+export SRUN_CPUS_PER_TASK=$SLURM_CPUS_PER_TASK


### PR DESCRIPTION
The current `slurm-archer2` header template does not set the `--cpus-per-task` Slurm job option from the `cpuspertask` environment variable. Being able to configure this option can be useful for example when wanting to run [a OpenMP+MPI mixed mode job](https://docs.archer2.ac.uk/user-guide/scheduler/#example-job-submission-script-for-mpiopenmp-mixed-mode-parallel-job) or [underpopulating a node with a processes](https://docs.archer2.ac.uk/user-guide/scheduler/#for-underpopulation-of-nodes-with-processes) (for example an MPI job that is not large enough to scale across the full 128 cores per node on ARCHER2). This PR updates the header template to set this Slurm job option from the (existing) environment variable `cpuspertask` (which defaults to 1).

This PR also updates the default `run_command` for running jobs on ARCHER2 to `srun --distribution=block:block --hint=nomultithread` which is the recommended run command in ARCHER2 documentation in the example job submission scripts for both [fully MPI](https://docs.archer2.ac.uk/user-guide/scheduler/#example-job-submission-script-for-mpi-parallel-job) and [mixed MPI+OpenMP jobs](https://docs.archer2.ac.uk/user-guide/scheduler/#example-job-submission-script-for-mpiopenmp-mixed-mode-parallel-job). The `--hint=nomultithread` option specifies to not use hyperthreads and `--distribution=block:block` option specifies to use a block distribution of proceses across nodes and sockets with nodes, with these options being [recommended as giving better performance over the default `srun` process placement](https://docs.archer2.ac.uk/user-guide/scheduler/#srun-launching-parallel-jobs). The `srun` command here is not explicitly passed a `-n` option as the task / process / node distribution is picked up automatically from the `sbatch` options.