### PR TITLE
Use OpenVPN credentials from environment

### DIFF
--- a/docs/advanced_topics.md
+++ b/docs/advanced_topics.md
@@ -274,3 +274,22 @@ fabsim myMachine dummy:dummy_test
 It is also possible to provide a plain text file containing the password by including `sshpass: 'path/to/password.secret'` in your `machine.yml` instead of providing it as an environment variable.  
 Make sure that the password is not readable by other users with `chmod g=-rwx,o=-rwx path/to/password.secret`.  
 **NOTE:** This does not provide any real security and the use of this method is highly discouraged!
+
+## OpenVPN
+When using machines across different private networks, the corresponding configuration in your `machine.yml` file may provide the required configuration file and optional credentials.  
+The same considerations as for the use of a password file for `sshpass` apply here.
+
+Example:
+```yml
+myMachine:
+  openvpn_config: /path/to/config.ovpn
+  openvpn_auth_user_pass: /path/to/auth-user-pass
+```
+The credentials may be provided as environment variables if `openvpn_auth_user_pass` is set to `true`:
+```bash
+# Avoid leaking credentials to ~/.bash_history
+read -sr OPENVPN_AUTH_USER && export OPENVPN_AUTH_USER
+read -sr OPENVPN_AUTH_PASS && export OPENVPN_AUTH_PASS
+# OPENVPN_AUTH_USER and OPENVPN_AUTH_PASS are used if openvpn_auth_user_pass is set to true
+fabsim myMachine dummy:dummy_test
+```

--- a/fabsim/base/utils.py
+++ b/fabsim/base/utils.py
@@ -1,7 +1,9 @@
 import inspect
+import os
 import platform
 import subprocess
 import sys
+from tempfile import NamedTemporaryFile
 import time
 from contextlib import contextmanager
 from os import system
@@ -138,10 +140,12 @@ class OpenVPNContext(object):
     ```
     """
 
+    _AUTH_ENV_KEYS = ['OPENVPN_AUTH_USER', 'OPENVPN_AUTH_PASS']
+
     def __init__(self, env):
         self._config = None
         self._auth_user_pass = None
-        path_err_msg = 'The value of X for this machine is not a valid file.'
+        path_err_msg = 'The value of X for this machine is not a valid file or boolean.'
         if hasattr(env, "openvpn_config"):
             self._config = env.openvpn_config
             if not Path(self._config).is_file():
@@ -149,9 +153,15 @@ class OpenVPNContext(object):
                 exit(1)
         if hasattr(env, "openvpn_auth_user_pass"):
             self._auth_user_pass = env.openvpn_auth_user_pass
-            if not Path(self._auth_user_pass).is_file():
+            if type(self._auth_user_pass) != bool or \
+                (type(self._auth_user_pass) == str and
+                    not Path(self._auth_user_pass).is_file()):
                 print(path_err_msg.replace(
                     'X', self._auth_user_pass), file=sys.stderr)
+                exit(1)
+            if len(set(OpenVPNContext._AUTH_ENV_KEYS).intersection(os.environ)) != 2:
+                print(' and '.join(OpenVPNContext._AUTH_ENV_KEYS) +
+                      'must be set in environment if openvpn_auth_user_pass is true.')
                 exit(1)
 
     def _print(msg):
@@ -170,11 +180,19 @@ class OpenVPNContext(object):
             cmd = ["openvpn", "--config", self._config]
             if platform.system().lower() in ["linux", "darwin"]:
                 cmd = ["sudo", "-n"] + cmd  # OpenVPN requires root privileges
-            if self._auth_user_pass is not None:
-                cmd += ["--auth-user-pass", self._auth_user_pass]
-            self._p = subprocess.Popen(cmd, stdout=subprocess.DEVNULL)
-            # Wait a bit for the VPN connection to be established
-            time.sleep(3)
+            # Create a temporary file for holding credentials from environment
+            # (Workaround, because the shell might not support the <() operator)
+            with NamedTemporaryFile(mode='wt', delete=True) as temporaryFile:
+                if self._auth_user_pass == True:
+                    for v in OpenVPNContext._AUTH_ENV_KEYS:
+                        temporaryFile.write(f'{os.environ[v]}\n')
+                    temporaryFile.flush()
+                    self._auth_user_pass = temporaryFile.name
+                if type(self._auth_user_pass) is str:
+                    cmd += ["--auth-user-pass", self._auth_user_pass]
+                self._p = subprocess.Popen(cmd, stdout=subprocess.DEVNULL)
+                # Wait a bit for the VPN connection to be established
+                time.sleep(3)
             if platform.system().lower() in ["linux", "darwin"]:
                 system("stty sane")  # sudo messes up the terminal output
             if self._p.poll() is not None:

--- a/fabsim/base/utils.py
+++ b/fabsim/base/utils.py
@@ -3,12 +3,12 @@ import os
 import platform
 import subprocess
 import sys
-from tempfile import NamedTemporaryFile
 import time
 from contextlib import contextmanager
 from os import system
 from pathlib import Path
 from pprint import pprint
+from tempfile import NamedTemporaryFile
 
 from beartype.typing import Dict
 from rich import print as rich_print

--- a/fabsim/base/utils.py
+++ b/fabsim/base/utils.py
@@ -154,8 +154,8 @@ class OpenVPNContext(object):
         env_key_auth = 'openvpn_auth_user_pass'
         if hasattr(env, env_key_auth):
             self._auth_user_pass = env[env_key_auth]
-            if type(self._auth_user_pass) != bool or \
-                (type(self._auth_user_pass) == str and
+            if not isinstance(self._auth_user_pass, bool) or \
+                (isinstance(self._auth_user_pass, str) and
                     not Path(self._auth_user_pass).is_file()):
                 print(path_err_msg.replace(
                     'X', self._auth_user_pass)[:-1] + ' or boolean.',

--- a/fabsim/deploy/machines.yml
+++ b/fabsim/deploy/machines.yml
@@ -83,6 +83,7 @@ default:
   # openvpn_config: /path/to/config.ovpn
 
   # When connecting through OpenVPN, a username and password can be provided in a separate file
+  # (set this value to true instead to use OPENVPN_AUTH_USER and OPENVPN_AUTH_PASS from the environment)
   # openvpn_auth_user_pass: /path/to/auth-user-pass.txt
 
   # Flag to use 'monsoon mode', which avoids rsync altogether and copies 


### PR DESCRIPTION
Closes #260.

Sadly I had to resort to writing the credentials to a temporary file, but that won't be so bad, since it is [private](https://hg.python.org/cpython/file/4243df51fe43/Lib/tempfile.py#l260) and is deleted shortly after the OpenVPN client reads the credentials.