### PR TITLE
Update rsync exclude-options

### DIFF
--- a/fabsim/base/fab.py
+++ b/fabsim/base/fab.py
@@ -306,7 +306,6 @@ def put_configs(config: str) -> None:
             local_dir=env.job_config_path_local + "/",
             remote_dir=env.job_config_path,
             delete=rsync_delete,
-            exclude=["file1.txt", "dir1/*", "dir2"],
         )
 
 

--- a/fabsim/base/networks.py
+++ b/fabsim/base/networks.py
@@ -266,7 +266,7 @@ def rsync_project(
 
     # create --exclude options from exclude list
     if len(exclude) > 0:
-        exclude_opts = " ".join(["--exclude {}".format(item) for item in exclude])
+        exclude_opts = " ".join(["--exclude={}".format(item) for item in exclude])
     else:
         exclude_opts = ""
 

--- a/fabsim/base/networks.py
+++ b/fabsim/base/networks.py
@@ -266,7 +266,9 @@ def rsync_project(
 
     # create --exclude options from exclude list
     if len(exclude) > 0:
-        exclude_opts = " ".join(["--exclude={}".format(item) for item in exclude])
+        exclude_opts = " ".join(
+            ["--exclude={}".format(item) for item in exclude]
+        )
     else:
         exclude_opts = ""
 

--- a/fabsim/base/networks.py
+++ b/fabsim/base/networks.py
@@ -266,9 +266,7 @@ def rsync_project(
 
     # create --exclude options from exclude list
     if len(exclude) > 0:
-        exclude_opts = "--exclude={%s}" % (
-            ",".join(["'{}'".format(item) for item in exclude])
-        )
+        exclude_opts = " ".join(["--exclude {}".format(item) for item in exclude])
     else:
         exclude_opts = ""
 


### PR DESCRIPTION
# 1. When using the `rsync`-command, the exclude flag does not work as intended.

According to documentation of rsync, in order to exclude files from the file-transfer, one may set the flag `--exclude=<filename>`.
To ignore multiple files, both versions are suggested:
`rsync --exclude={'file1.txt', 'file2.txt', 'dir1/' } ...`
and
`rsync --exclude=file1.txt --exclude=file2.txt --exclude=dir1/ ...`

With my setup (Ubuntu 22.04 LTS, rsync 3.2.7), the first option does not exclude the specified files from the file-transfer.
This first pattern is currently implemented in FabSim in the `rsync_project`-function in `networks.py`.

Outputs:
```sh
[local] rsync  --exclude={'file1.txt','dir1/*','dir2'} -pthrvz --rsh='ssh -p 22 ' /home/jo/repos/FabSim3/plugins/FabMaMiCo/config_files/my_installation/ [michaelj@hsuper-login.hsu-hh.de](mailto:michaelj@hsuper-login.hsu-hh.de):/beegfs/home/m/michaelj/FabSim/config_files/my_installation/
sending incremental file list
./
fabmamico_user_config.yml
file1.txt
file_with_random_content.txt
task mamico_install:<config>
dir1/
dir1/file2.txt
dir2/
dir2/file3.txt
```

```sh
[local] rsync  --exclude=file1.txt --exclude=dir1/* --exclude=dir2 -pthrvz --rsh='ssh -p 22 ' /home/jo/repos/FabSim3/plugins/FabMaMiCo/config_files/my_installation/ michaelj@hsuper-login.hsu-hh.de:/beegfs/home/m/michaelj/FabSim/config_files/my_installation/
sending incremental file list
./
fabmamico_user_config.yml
file_with_random_content.txt
task mamico_install:<config>
dir1/
```

You can reproduce the behavior by creating according files in the fabDummy `config_files`-directory.


# 2. Default exclusion of "file1.txt", "dir1/*", "dir2"
Furthermore, by default, the `put_configs`-function ignores the files `["file1.txt", "dir1/*", "dir2"]`.
In case a user does have these files in their config-directory, this might lead to unexpected behavior.
