### PR TITLE
Add missing import statement for numpy

### DIFF
--- a/fabsim/base/fab.py
+++ b/fabsim/base/fab.py
@@ -6,8 +6,8 @@ import tempfile
 from pathlib import Path
 from pprint import pformat, pprint
 from shutil import copy, copyfile, rmtree
-import numpy as np
 
+import numpy as np
 from beartype import beartype
 from beartype.typing import Callable, Optional, Tuple, Union
 from rich import print as rich_print

--- a/fabsim/base/fab.py
+++ b/fabsim/base/fab.py
@@ -6,6 +6,7 @@ import tempfile
 from pathlib import Path
 from pprint import pformat, pprint
 from shutil import copy, copyfile, rmtree
+import numpy as np
 
 from beartype import beartype
 from beartype.typing import Callable, Optional, Tuple, Union


### PR DESCRIPTION
The file `fab.py` contains a call to `np.arrange(..)` (here: https://github.com/djgroen/FabSim3/blob/9194ed5dbc3bbb88fe7b917c5158586db8f77fe2/fabsim/base/fab.py#L1337) , however there is no explicit import-statement for numpy.
numpy is also not loaded via a `from <x> import *`.