### PR TITLE
Bugfix: run with cd

### DIFF
--- a/fabsim/base/networks.py
+++ b/fabsim/base/networks.py
@@ -157,8 +157,8 @@ def manual_sshpass(
     else:
         commands = []
 
-    if env.get("cwd"):
-        commands.append("cd {}".format(env.cwd))
+    if cd is not None:
+        commands.append("cd {}".format(cd))
 
     commands.append(cmd)
     manual_command = " && ".join(commands)
@@ -180,8 +180,8 @@ def manual_gsissh(
     else:
         commands = []
 
-    if env.get("cwd"):
-        commands.append("cd {}".format(env.cwd))
+    if cd is not None:
+        commands.append("cd {}".format(cd))
 
     commands.append(cmd)
     manual_command = " && ".join(commands)
@@ -199,8 +199,8 @@ def manual(
     else:
         commands = []
 
-    if env.get("cwd"):
-        commands.append("cd {}".format(env.cwd))
+    if cd is not None:
+        commands.append("cd {}".format(cd))
 
     commands.append(cmd)
     manual_command = " && ".join(commands)


### PR DESCRIPTION
The functions `manual_sshpass()`, `manual_gsissh()`, `manual()` in `networks.py` accept multiple arguments.
The argument `cd` however is not considered anywhere in the functions and is therefore useless.

As a plugin-developer, I would expect the command passed to the function to be run in the directory that is given by the optional argument `cd`.

Thus, the function should check against the passed argument and not against the environment-variable `cwd`.