### PR TITLE
Feature: Add machines_user_backup.yml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ fabsim/deploy/machines_user.yml
 
 fabsim/deploy/machines_private.yml
 
+fabsim/deploy/machines_user_backup.yml
+
 base/__pycache__/
 
 fabsim/deploy/\.jobscripts/


### PR DESCRIPTION
The file `machines_user_backup.yml` is automatically created when running `python configure_fabsim.py`.

The backup file should never be committed to the repository, and thus should appear in the `.gitignore`-file.