### PR TITLE
Renaming FabCannonSim to FabCannonsim in plugins.yml | #297

### DIFF
--- a/fabsim/deploy/plugins.yml
+++ b/fabsim/deploy/plugins.yml
@@ -14,7 +14,7 @@ FabDummy:
 FabGuard:
   repository: https://github.com/rumineykova/fabguard.git
 
-FabCannonSim:
+FabCannonsim:
   repository: https://github.com/arabnejad/FabCannonsim.git
 
 FabMaMiCo:


### PR DESCRIPTION
See issue #297.